### PR TITLE
Feature/skip validation when setting user token

### DIFF
--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -53,15 +53,16 @@ module DeviseTokenAuth
     end
 
     def destroy
-      # remove auth instance variables so that after_filter does not run
+      # remove auth instance variables so that after_action does not run
       user = remove_instance_variable(:@resource) if @resource
       client_id = remove_instance_variable(:@client_id) if @client_id
       remove_instance_variable(:@token) if @token
 
       if user and client_id and user.tokens[client_id]
+        # replaced save! by update_columns to avoid
+        # callbacks & validations
         user.tokens.delete(client_id)
-        user.save!
-
+        user.update_columns(tokens: user.tokens)
         yield if block_given?
 
         render_destroy_success


### PR DESCRIPTION
Fixed issues:

Basically the devise_token_auth logic for the log-in/out was changed. devise_token_auth checked whether the object is valid when it updated the token header. If was not a valid object it did not add the token header to the response & the client had no credentials in the end. To solve that, first the check whether an object is valid was removed & the call of save! was replaced by update_columns which does not do validations nor callbacks.

A similar problem occurred in the sign-out.